### PR TITLE
3.1.0: Reduce overhead of calling a method 

### DIFF
--- a/Michi.Tests/Michi.Tests.csproj
+++ b/Michi.Tests/Michi.Tests.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EnumeratorTests.cs" />
+    <Compile Include="RemoteFunctionArityTests.cs" />
     <Compile Include="RemoteHandlerTests.cs" />
     <Compile Include="RemoteFunctionContainerTests.cs" />
     <Compile Include="RemoteFunctionTests.cs" />

--- a/Michi.Tests/RemoteFunctionArityTests.cs
+++ b/Michi.Tests/RemoteFunctionArityTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Michi.Functions;
+namespace Michi.Tests
+{
+    public class RemoteFunctionArityTests
+    {
+        [Fact]
+        public void Func0() => 
+            RemoteFunction.Make<string>(() => "Hello World");
+        [Fact]
+        public void Func1() => 
+            RemoteFunction.Make<object, string>((x) => "Hello World");
+        [Fact]
+        public void Func2() => 
+            RemoteFunction.Make<object, object, string>((x, y) => "Hello World");
+        [Fact]
+        public void Func3() => 
+            RemoteFunction.Make<object, object, object, string>((x, y, z) => "Hello World");
+        [Fact]
+        public void Func4() => 
+            RemoteFunction.Make<object, object, object, object, string>((x, y, z, a) => "Hello World");
+        [Fact]
+        public void Func5() => 
+            RemoteFunction.Make<object, object, object, object, object, string>((x, y, z, a, b) => "Hello World");
+        [Fact]
+        public void Func6() =>
+            RemoteFunction.Make<object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c) => "Hello World");
+        [Fact]
+        public void Func7() => 
+            RemoteFunction.Make<object, object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d) => "Hello World");
+        [Fact]
+        public void Func8() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e) => "Hello World");
+        [Fact]
+        public void Func9() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f) => "Hello World");
+        [Fact]
+        public void Func10() => 
+            RemoteFunction.Make<object, object, object, object, object, object, object, 
+                object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g) => "Hello World");
+        [Fact]
+        public void Func11() => 
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g, h) => "Hello World");
+        [Fact]
+        public void Func12() =>
+             RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g, h, i) => "Hello World");
+        [Fact]
+        public void Func13() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j) => "Hello World");
+        [Fact]
+        public void Func14() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j, k) => "Hello World");
+        [Fact]
+        public void Func15() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object, object, object, string>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j, k, l) => "Hello World");
+        [Fact]
+        public void Action0() =>
+            RemoteFunction.Make(() => { });
+        [Fact]
+        public void Action1() =>
+            RemoteFunction.Make<object>((x) => { });
+        [Fact]
+        public void Action2() =>
+            RemoteFunction.Make<object, object>((x, y) => { });
+        [Fact]
+        public void Action3() =>
+            RemoteFunction.Make<object, object, object>((x, y, z) => { });
+        [Fact]
+        public void Action4() =>
+            RemoteFunction.Make<object, object, object, object>((x, y, z, a) => { });
+        [Fact]
+        public void Action5() =>
+            RemoteFunction.Make<object, object, object, object, object>((x, y, z, a, b) => { });
+        [Fact]
+        public void Action6() =>
+            RemoteFunction.Make<object, object, object, object, object, object>
+            ((x, y, z, a, b, c) => { });
+        [Fact]
+        public void Action7() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d) => { });
+        [Fact]
+        public void Action8() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e) => { });
+        [Fact]
+        public void Action9() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f) => { });
+        [Fact]
+        public void Action10() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g) => { });
+        [Fact]
+        public void Action11() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g, h) => { });
+        [Fact]
+        public void Action12() =>
+             RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g, h, i) => { });
+        [Fact]
+        public void Action13() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j) => { });
+        [Fact]
+        public void Action14() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j, k) => { });
+        [Fact]
+        public void Action15() =>
+            RemoteFunction.Make<object, object, object, object, object, object, object,
+                object, object, object, object, object, object, object, object>
+            ((x, y, z, a, b, c, d, e, f, g, h, i, j, k, l) => { });
+    }
+}

--- a/Michi/Functions/MethodInfoExtensions.cs
+++ b/Michi/Functions/MethodInfoExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+namespace Michi.Functions
+{
+    internal static class MethodInfoExtensions
+    {
+        internal static string[] GetParameterNames(this MethodInfo @methodInfo)
+        {
+            ParameterInfo[] parameterInfos = @methodInfo.GetParameters();
+            string[] parameterNames = new string[parameterInfos.Length];
+            foreach (var param in parameterInfos)
+            {
+                parameterNames[param.Position] = param.Name; //must preserve order
+            }
+            return parameterNames;
+        }
+    }
+}

--- a/Michi/Functions/RemoteFunction.Make.cs
+++ b/Michi/Functions/RemoteFunction.Make.cs
@@ -11,172 +11,573 @@ namespace Michi.Functions
         {
             var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
                             new RemoteFunctionAttribute(method.Method.Name);
-            return new RemoteFunction((parameters) => method, methodData.MethodName, methodData.MethodNamespace);
+            return new RemoteFunction((p) => method(), methodData.MethodName, methodData.MethodNamespace);
         }
 
         public static RemoteFunction Make<T1, TResult>(Func<T1, TResult> method)
         {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                           new RemoteFunctionAttribute(method.Method.Name);
             var paramNames = method.Method.GetParameterNames();
-            return new RemoteFunction((parameters) => method(parameters.Param<T1>(paramNames[0])));
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0])),
+                methodData.MethodName, methodData.MethodNamespace);
         }
-
-
 
         public static RemoteFunction Make<T1, T2, TResult>(Func<T1, T2, TResult> method)
         {
-
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]), p.Param<T2>(paramNames[1])),
+                methodData.MethodName, methodData.MethodNamespace);
         }
 
 
         public static RemoteFunction Make<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]), 
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, TResult>(
             Func<T1, T2, T3, T4, T5, T6, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>
             (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13]),
+                p.Param<T15>(paramNames[14])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
 
         public static RemoteFunction Make
             <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13]),
+                p.Param<T15>(paramNames[14]),
+                p.Param<T16>(paramNames[15])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
         #endregion
 
         #region Actions
-
         public static RemoteFunction Make(Action method)
-           => RemoteFunction.Make((Delegate)method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                            new RemoteFunctionAttribute(method.Method.Name);
+            return new RemoteFunction((p) => method(), methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1>(Action<T1> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                           new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2>(Action<T1, T2> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]), p.Param<T2>(paramNames[1])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
 
         public static RemoteFunction Make<T1, T2, T3>(Action<T1, T2, T3> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4>(Action<T1, T2, T3, T4> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6>(
             Action<T1, T2, T3, T4, T5, T6> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7>(
             Action<T1, T2, T3, T4, T5, T6, T7> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
             (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13]),
+                p.Param<T15>(paramNames[14])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
 
 
         public static RemoteFunction Make
             <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                                     new RemoteFunctionAttribute(method.Method.Name);
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
+                p.Param<T2>(paramNames[1]),
+                p.Param<T3>(paramNames[2]),
+                p.Param<T4>(paramNames[3]),
+                p.Param<T5>(paramNames[4]),
+                p.Param<T6>(paramNames[5]),
+                p.Param<T7>(paramNames[6]),
+                p.Param<T8>(paramNames[7]),
+                p.Param<T9>(paramNames[8]),
+                p.Param<T10>(paramNames[9]),
+                p.Param<T11>(paramNames[10]),
+                p.Param<T12>(paramNames[11]),
+                p.Param<T13>(paramNames[12]),
+                p.Param<T14>(paramNames[13]),
+                p.Param<T15>(paramNames[14]),
+                p.Param<T16>(paramNames[15])),
+                methodData.MethodName, methodData.MethodNamespace);
+        }
         #endregion
 
     }

--- a/Michi/Functions/RemoteFunction.Make.cs
+++ b/Michi/Functions/RemoteFunction.Make.cs
@@ -8,15 +8,24 @@ namespace Michi.Functions
         #region Functions
 
         public static RemoteFunction Make<TResult>(Func<TResult> method)
-            => RemoteFunction.Make((Delegate) method);
-
+        {
+            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
+                            new RemoteFunctionAttribute(method.Method.Name);
+            return new RemoteFunction((parameters) => method, methodData.MethodName, methodData.MethodNamespace);
+        }
 
         public static RemoteFunction Make<T1, TResult>(Func<T1, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+            var paramNames = method.Method.GetParameterNames();
+            return new RemoteFunction((parameters) => method(parameters.Param<T1>(paramNames[0])));
+        }
+
 
 
         public static RemoteFunction Make<T1, T2, TResult>(Func<T1, T2, TResult> method)
-            => RemoteFunction.Make((Delegate) method);
+        {
+
+        }
 
 
         public static RemoteFunction Make<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> method)
@@ -170,11 +179,5 @@ namespace Michi.Functions
 
         #endregion
 
-        private static RemoteFunction Make(Delegate method)
-        {
-            var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
-                             new RemoteFunctionAttribute(method.Method.Name);
-            return new RemoteFunction(method.Method, method.Target, methodData.MethodName, methodData.MethodNamespace);
-        }
     }
 }

--- a/Michi/Functions/RemoteFunction.Make.cs
+++ b/Michi/Functions/RemoteFunction.Make.cs
@@ -38,7 +38,7 @@ namespace Michi.Functions
             var methodData = method.Method.GetCustomAttribute<RemoteFunctionAttribute>() ??
                                      new RemoteFunctionAttribute(method.Method.Name);
             var paramNames = method.Method.GetParameterNames();
-            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]), 
+            return new RemoteFunction((p) => method(p.Param<T1>(paramNames[0]),
                 p.Param<T2>(paramNames[1]),
                 p.Param<T3>(paramNames[2])),
                 methodData.MethodName, methodData.MethodNamespace);

--- a/Michi/Functions/RemoteFunction.cs
+++ b/Michi/Functions/RemoteFunction.cs
@@ -14,28 +14,20 @@ namespace Michi.Functions
     /// </summary>
     public partial struct RemoteFunction
     {
-        private readonly MethodInfo methodInfo;
-        private readonly object methodTarget;
+        private readonly Func<RemoteFunctionParameters, object> function;
         public string MethodNamespace { get; }
         public string MethodName { get; }
 
-        RemoteFunction(MethodInfo methodInfo, object methodTarget, string methodName, string methodNamespace)
+        RemoteFunction(Func<RemoteFunctionParameters, object> function, string methodName, string methodNamespace)
         {
-            this.methodInfo = methodInfo;
-            this.methodTarget = methodTarget;
+            this.function = function;
             this.MethodNamespace = methodNamespace;
             this.MethodName = methodName;
         }
 
         internal object Invoke(RemoteFunctionParameters remoteParameters)
         {
-            ParameterInfo[] parameterInfos = this.methodInfo.GetParameters();
-            object[] callingParameters = new object[parameterInfos.Length];
-            foreach (var param in parameterInfos)
-            {
-                callingParameters[param.Position] = remoteParameters.Param(param.Name);
-            }
-            return this.methodInfo.Invoke(this.methodTarget, callingParameters);
+            return this.function.Invoke(remoteParameters);
         }
     }
 }

--- a/Michi/Functions/RemoteFunction.cs
+++ b/Michi/Functions/RemoteFunction.cs
@@ -37,7 +37,7 @@ namespace Michi.Functions
             this.MethodName = methodName;
         }
 
-        internal object Invoke(RemoteFunctionParameters remoteParameters)
+        public object Invoke(RemoteFunctionParameters remoteParameters)
         {
             return this.function.Invoke(remoteParameters);
         }

--- a/Michi/Functions/RemoteFunction.cs
+++ b/Michi/Functions/RemoteFunction.cs
@@ -25,6 +25,18 @@ namespace Michi.Functions
             this.MethodName = methodName;
         }
 
+        RemoteFunction(Action<RemoteFunctionParameters> function, string methodName, string methodNamespace)
+        {
+            this.function = (p) =>
+            {
+                function(p);
+                return null;
+            };
+
+            this.MethodNamespace = methodNamespace;
+            this.MethodName = methodName;
+        }
+
         internal object Invoke(RemoteFunctionParameters remoteParameters)
         {
             return this.function.Invoke(remoteParameters);

--- a/Michi/Functions/RemoteFunctionParameters.cs
+++ b/Michi/Functions/RemoteFunctionParameters.cs
@@ -27,11 +27,6 @@ namespace Michi.Functions
             object value = this.parameterDictionary[key];
             return (value is T) ? (T)value : default(T);
          }
- 
-        internal object Param(string key)
-        {
-            return this.parameterDictionary.ContainsKey(key) ? this.parameterDictionary[key] : null;
-        }
 
         public void Add(string key, dynamic value)
         {

--- a/Michi/Functions/RemoteFunctionParameters.cs
+++ b/Michi/Functions/RemoteFunctionParameters.cs
@@ -21,6 +21,14 @@ namespace Michi.Functions
             this.parameterDictionary = new ConcurrentDictionary<string, object>();
         }
 
+         internal T Param<T>(string key)
+         {
+             if (!this.parameterDictionary.ContainsKey(key)) return default(T);
+             object value = this.parameterDictionary[key];
+             if (value is T) return (T)value;
+             return default(T);
+         }
+ 
         internal object Param(string key)
         {
             return this.parameterDictionary.ContainsKey(key) ? this.parameterDictionary[key] : null;

--- a/Michi/Functions/RemoteFunctionParameters.cs
+++ b/Michi/Functions/RemoteFunctionParameters.cs
@@ -28,7 +28,7 @@ namespace Michi.Functions
             return (value is T) ? (T)value : default(T);
          }
 
-        public void Add(string key, dynamic value)
+        public void Add(string key, object value)
         {
             this.parameterDictionary.Add(key, value);
         }

--- a/Michi/Functions/RemoteFunctionParameters.cs
+++ b/Michi/Functions/RemoteFunctionParameters.cs
@@ -23,10 +23,9 @@ namespace Michi.Functions
 
          internal T Param<T>(string key)
          {
-             if (!this.parameterDictionary.ContainsKey(key)) return default(T);
-             object value = this.parameterDictionary[key];
-             if (value is T) return (T)value;
-             return default(T);
+            if (!this.parameterDictionary.ContainsKey(key)) return default(T);
+            object value = this.parameterDictionary[key];
+            return (value is T) ? (T)value : default(T);
          }
  
         internal object Param(string key)

--- a/Michi/Michi.csproj
+++ b/Michi/Michi.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Functions\MethodInfoExtensions.cs" />
     <Compile Include="Functions\RemoteFunction.cs" />
     <Compile Include="Functions\RemoteFunctionAttribute.cs" />
     <Compile Include="Functions\RemoteFunctionContainer.cs" />

--- a/Michi/Properties/AssemblyInfo.cs
+++ b/Michi/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]


### PR DESCRIPTION
This PR reduces the overhead of calling a method with parameters from 2-300ms to > 5ms.

Delegates passed to RemoteFunction.Make() now have their parameter names inlined at instantiation time instead of being added at invoke time by wrapping the method call into a lambda, so Reflection on the MethodInfo is done only once, instead of every time the method is called.

This also replaces every use of `dynamic` with `object`. This makes the individual function calls take from up to 300ms to less than 5ms, since there is no longer any reliance on the DLR, relying on simple casting.
